### PR TITLE
fix bug "formatting issue with 'c', 'java' style" (#17)

### DIFF
--- a/lice2/helpers.py
+++ b/lice2/helpers.py
@@ -198,7 +198,7 @@ def format_license(
         out.write(prefix)
         for line in template:
             # ensure no extra whitespace is added for blank lines
-            out.write(comment if line.strip() else comment.strip())
+            out.write(comment if line.strip() else comment.rstrip())
             out.write(line)
         out.write(postfix)
 

--- a/lice2/tests/test_lice.py
+++ b/lice2/tests/test_lice.py
@@ -389,6 +389,16 @@ def test_format_license_no_lang() -> None:
     assert result.getvalue() == TEMPLATE_FILE
 
 
+def test_format_license_empty_lines() -> None:
+    """Test the 'format_license' function with empty lines."""
+    content = StringIO("\n\nThis is a test.\n")
+    result = format_license(content, "py")
+
+    expected = "#\n#\n# This is a test.\n"
+
+    assert result.getvalue() == expected
+
+
 def test_load_file_template_path_not_found() -> None:
     """Test the 'load_file_template' function with a bad path."""
     with pytest.raises(ValueError, match="path does not exist"):


### PR DESCRIPTION
Fixes #17, which led to bad formatting when creating C, Java or languages using the same template.