### PR TITLE
Provide an optional JSON output, listing licenses and languages for easier integration into other tools like a GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,18 @@
 This is an auto-generated log of all the changes that have been made to the
 project since release 0.7.0.
 
-For the original changelog, please refer to the [OLD_CHANGELOG.md](OLD_CHANGELOG.md).
+For the original changelog, please refer to the "OLD_CHANGELOG.md" file in the repository.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased](https://github.com/seapagan/lice2/tree/HEAD)
+
+**New Features**
+
+- Add '--version' flag to the CLI ([#29](https://github.com/seapagan/lice2/pull/29)) by [seapagan](https://github.com/seapagan)
+
+[`Full Changelog`](https://github.com/seapagan/lice2/compare/0.11.0...HEAD) | [`Diff`](https://github.com/seapagan/lice2/compare/0.11.0...HEAD.diff) | [`Patch`](https://github.com/seapagan/lice2/compare/0.11.0...HEAD.patch)
 
 ## [0.11.0](https://github.com/seapagan/lice2/releases/tag/0.11.0) (August 28, 2024)
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Lice generates license files. No more hunting down licenses from other projects.
 - [I want XXXXXXXXX license in here!](#i-want-xxxxxxxxx-license-in-here)
 - [Usage](#usage)
 - [Config File](#config-file)
+- [Integration with other tools](#integration-with-other-tools)
 - [Changelog](#changelog)
 
 ## Changes from the original 'Lice' project
@@ -39,6 +40,8 @@ features:
   added.
 - It passes strict linting with the latest 'Ruff' and 'mypy'.
 - GitHub actions set up for linting, `Dependabot` and `Dependency Review`.
+- Can output a list of licenses and languages in JSON format for integration
+  with other tools.
 
 In addition, future plans can be seen in the [TODO.md](TODO.md) file.
 
@@ -237,17 +240,39 @@ $ lice --help
 ## Config File
 
 The app will look for a config file in `~/.config/lice/config.toml`. This file
-can be used to set default values for the license and organization.
+can be used to set default values for the license and organization. See the
+documentation website for more information.
 
 ```toml
 [lice]
 default_license = "mit"
 organization = "Grant Ramsay"
 clipboard = false
+legacy = false
 ```
 
 The 'default_license' is checked at run-time, and if it is not valid then it
 falls back to the BSD-3 license.
+
+## Integration with other tools
+
+**This is currently only available in the dev version.**
+
+This tool can output a list of availailable licenses and languages in JSON
+format. This can be used to integrate with other tools. For example, to get a
+list of licenses in JSON format:
+
+```console
+lice --metadata
+```
+
+The output will have 4 keys: `licenses`, `languages`, `organization` and
+`project` which another tool can use to populate a list of licenses and
+languages in a GUI for example. The first two keys are simple lists of strings
+that can be parsed.
+
+Future versions will have an actual python api that can be imported in other
+python projects to generate licenses from within the project.
 
 ## Changelog
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@
 <!-- - All improvements and ideas I have had so far have been implemented in the -->
 <!--   project. I'm always open to new ideas and improvements, so if you have any -->
 <!--   suggestions, please let me know. -->
-- Add option for `--licenses` and perhaps `--languages` to output in `JSON`
-format for integration in other tools. Maybe also an option on the root command
-to output both combined.
+- add an api so that other tools can use the license generation functionality
+  without having to shell out to the command line
+- add a GUI for the license generation (use Textual for this). This would be
+  accessed through a CLI option or a config file setting.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,10 +15,11 @@ The TOML file should look like this:
 [lice]
 default_license = "mit"
 organization = "Your Organization"
-legacy = true
+clipboard = false
+legacy = false
 ```
 
-Currently there are only three options that can be set:
+Currently there are four options that can be set:
 
 - `default_license` - This is the default license that will be used if no
   license is specified on the command line. If this option is not set, it will
@@ -26,6 +27,10 @@ Currently there are only three options that can be set:
 - `organization` - This is the organization name that will be used in the
   license by default. If this is set, it will not try to get the organization
   name from `git config` or the `$USER` environment variable.
+- `clipboard` - This is a boolean value that will set the default behavior of the
+  application to copy the generated license to the clipboard. If this option is
+  not set, it will default to `false`. See the [--clipboard
+  option](usage.md#-clipboard-c-option) for more information.
 - `legacy` - This is a boolean value that will set the default style license
   generation to the old style with extra spaces and newlines. If this option is
   not set, it will default to `false`. See the [--legacy

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,8 @@ features:
   added.
 - It passes strict linting with the latest 'Ruff' and 'mypy'.
 - GitHub actions set up for linting, `Dependabot` and `Dependency Review`.
+- Can output a list of licenses and languages in JSON format for integration
+  with other tools.
 
 In addition, future plans can be seen in the [Future Plans](future_plans.md)
 page.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -91,7 +91,8 @@ lice -t "./path/to/template.txt"
 
 ### `--year` / `-y` option
 
-This will allow you to specify a year to be used in the license.
+This will allow you to specify a year to be used in the license. If you don't
+specify a year, it will default to the current year.
 
 ```console
 lice -y 2024
@@ -188,6 +189,23 @@ This will list all the available source code formatting languages.
 ```console
 lice --languages
 ```
+
+### `--metadata` option
+
+This will output a JSON object containing a list of all the licenses and
+languages available.
+
+```console
+lice --metadata
+```
+
+The output will have 4 keys: `licenses`, `languages`, `organization` and
+`project` which another tool can use to populate a list of licenses and
+languages in a GUI for example. The first two keys are simple lists of strings
+that can be parsed.
+
+Future versions will have an actual python api that can be imported in other
+python projects to generate licenses from within the project.
 
 ### `--install-completion` option
 

--- a/lice2/core.py
+++ b/lice2/core.py
@@ -22,6 +22,7 @@ from lice2.helpers import (
     generate_license,
     get_context,
     get_lang,
+    get_metadata,
     get_suffix,
     guess_organization,
     list_languages,
@@ -43,7 +44,7 @@ app = typer.Typer(rich_markup_mode="rich")
     ),
     context_settings={"help_option_names": ["-h", "--help"]},
 )
-def main(  # noqa: PLR0912, PLR0913
+def main(  # noqa: C901, PLR0912, PLR0913
     license_name: Annotated[
         str,
         typer.Argument(
@@ -108,7 +109,7 @@ def main(  # noqa: PLR0912, PLR0913
             "-f",
             help=(
                 "Name of the output source file (with -l, "
-                "extension can be ommitted)"
+                "extension can be omitted)"
             ),
         ),
     ] = "stdout",
@@ -154,6 +155,16 @@ def main(  # noqa: PLR0912, PLR0913
             "--version", "-v", is_eager=True, help="Show version info"
         ),
     ] = False,
+    metadata: Annotated[
+        bool,
+        typer.Option(
+            "--metadata",
+            help=(
+                "Output a JSON string listing all available licenses and "
+                "languages This allows easy integration into other tools."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Generate a license file.
 
@@ -188,6 +199,13 @@ def main(  # noqa: PLR0912, PLR0913
     # convert to SimpleNamespace, so we can use dot notation
     args = SimpleNamespace(**args_base)
 
+    # get the language if set
+    lang = get_lang(args)
+
+    # output metadata as JSON if requested
+    if metadata:
+        get_metadata(args)
+
     # list available licenses and their template variables
     if args.list_licenses:
         list_licenses()
@@ -195,9 +213,6 @@ def main(  # noqa: PLR0912, PLR0913
     # list available source formatting languages
     if args.list_languages:
         list_languages()
-
-    # language
-    lang = get_lang(args)
 
     # generate header if requested
     if header:

--- a/lice2/helpers.py
+++ b/lice2/helpers.py
@@ -1,6 +1,7 @@
 """Helper functions for LICE2."""
 
 import getpass
+import json
 import os
 import re
 import subprocess
@@ -321,3 +322,22 @@ def copy_to_clipboard(out: StringIO) -> None:
             fg=typer.colors.BRIGHT_RED,
         )
         raise typer.Exit(2) from None
+
+
+def get_metadata(args: SimpleNamespace) -> str:
+    """Return metadata for the package as a JSON string."""
+    licenses = LICENSES
+    languages = list(LANGS.keys())
+    organization = args.organization
+    project = args.project
+
+    metadata = {
+        "languages": languages,
+        "licenses": licenses,
+        "organization": organization,
+        "project": project,
+    }
+
+    sys.stdout.write(json.dumps(metadata) + "\n")
+
+    raise typer.Exit(0)

--- a/lice2/tests/test_cli.py
+++ b/lice2/tests/test_cli.py
@@ -117,3 +117,14 @@ def test_cli_version_command() -> None:
     assert result.exit_code == 0
     assert "Lice2" in result.output
     assert "Version" in result.output
+
+
+def test_metadata_command() -> None:
+    """Test the CLI metadata command.
+
+    We already test the actual JSON output in the unit tests, so we just check
+    that the command runs successfully here.
+    """
+    result = runner.invoke(app, ["--metadata"])
+
+    assert result.exit_code == 0

--- a/lice2/tests/test_lice.py
+++ b/lice2/tests/test_lice.py
@@ -540,6 +540,11 @@ def test_get_metadata_is_valid_json(
 
     assert exc.value.exit_code == 0
 
+    json_keys = json_result.keys()
+
+    for key in ["organization", "project", "licenses", "languages"]:
+        assert key in json_keys
+
     assert json_result["organization"] == "Awesome Co."
     assert json_result["project"] == "my_project"
     assert licenses in captured.out


### PR DESCRIPTION
This will output a JSON string listing all the possible licenses and languages, for integration in other tools