### PR TITLE
Add an API so that lice can be used inside other applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 .changelog_generator.toml
 .python-version
 site/
+api-test.py

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Lice generates license files. No more hunting down licenses from other projects.
 - [I want XXXXXXXXX license in here!](#i-want-xxxxxxxxx-license-in-here)
 - [Usage](#usage)
 - [Config File](#config-file)
+- [Integrate into your projects](#integrate-into-your-projects)
 - [Integration with other tools](#integration-with-other-tools)
 - [Changelog](#changelog)
 
@@ -27,10 +28,12 @@ Lice generates license files. No more hunting down licenses from other projects.
 This version fixes the compatibility issue with Python 3.12, and adds some new
 features:
 
-- It now uses [Poetry](https://python-poetry.org/) for dependency management.
+- It has an API that can be imported into your Python projects to allow you to
+  generate licenses directly from within your own project.
 - Can read from a config file for default values.
 - Can optionally copy the license to the clipboard automatically.
 - Converted from 'argparse' to 'Typer' for CLI handling.
+- It now uses [Poetry](https://python-poetry.org/) for dependency management.
 - Fixes the issue where extra spaces and newlines were added to the generated
   license text. This was considered a bug by at least several users, so it was
   fixed in version `0.10.0`. However, if you want to generate a license with the
@@ -254,13 +257,31 @@ legacy = false
 The 'default_license' is checked at run-time, and if it is not valid then it
 falls back to the BSD-3 license.
 
+## Integrate into your projects
+
+**This is currently only available in the dev version.**
+
+Lice now includes an API that can be imported into your Python projects! This
+allows you to generate licenses from within your project. Here is an example:
+
+```python
+from lice2.api import Lice
+
+lice = Lice(organization="Awesome Organization", project="Awesome Project")
+license_text = lice.get_license("mit")
+print(license_text)
+```
+
+There are a few other methods available in the API, see the documentation for
+more information.
+
 ## Integration with other tools
 
 **This is currently only available in the dev version.**
 
 This tool can output a list of availailable licenses and languages in JSON
-format. This can be used to integrate with other tools. For example, to get a
-list of licenses in JSON format:
+format. This can be used to integrate with other non-Python tools. For example,
+to get a list of licenses in JSON format:
 
 ```console
 lice --metadata
@@ -271,8 +292,7 @@ The output will have 4 keys: `licenses`, `languages`, `organization` and
 languages in a GUI for example. The first two keys are simple lists of strings
 that can be parsed.
 
-Future versions will have an actual python api that can be imported in other
-python projects to generate licenses from within the project.
+For more fine-grained control, you can use the API above (but only in Python)
 
 ## Changelog
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,13 @@
 <!-- - All improvements and ideas I have had so far have been implemented in the -->
 <!--   project. I'm always open to new ideas and improvements, so if you have any -->
 <!--   suggestions, please let me know. -->
-- add an api so that other tools can use the license generation functionality
-  without having to shell out to the command line
 - add a GUI for the license generation (use Textual for this). This would be
   accessed through a CLI option or a config file setting.
+- add an option to list licenses that have a header available. Maybe this could
+  be done with a `--list-headers` option or `--headers --list`.
+- new languages to support - `go`, `typescript`, etc.
+- add a 'human readable' value to the internal LICENSES list so we can display
+  the license name in a more human readable format. This would be especially
+  useful for the `--licenses` option and the API. The issue is that this
+  variable is dynamically generated from the license files, so having a human
+  readable value would be difficult to maintain.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,6 @@ page.
     This application is now only compatible with Python 3.9 and above. If you
     wish to use an older version, use the original 'lice' package.
 
-    However, I'ts the **development** dependencies that are causing the
+    However, It's the **development** dependencies that are causing the
     incompatibility, so I'll look at reducing the **Production** version in
     future releases while still requiring Python 3.9 or above for development.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,11 +14,13 @@ Lice generates license files. No more hunting down licenses from other projects.
 This version fixes the compatibility issue with Python 3.12, and adds some new
 features:
 
-- It now uses [Poetry](https://python-poetry.org/){:target="_blank"} for
-  dependency management.
+- It has an API that can be imported into your Python projects to allow you to
+  generate licenses directly from within your own project.
 - Can read from a config file for default values.
 - Can optionally copy the license to the clipboard automatically.
 - Converted from 'argparse' to 'Typer' for CLI handling.
+- It now uses [Poetry](https://python-poetry.org/){:target="_blank"} for
+  dependency management.
 - Fixes the issue where extra spaces and newlines were added to the generated
   license text. This was considered a bug by at least several users, so it was
   fixed in version `0.10.0`. However, if you want to generate a license with the

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,213 @@
+# Integrating 'Lice2' in your own project
+
+## Overview
+
+Starting version `0.12.0`, you can use `Lice2` as an API in your own project to
+generate licenses. Here is an example:
+
+```python
+from lice2.api import Lice
+
+lice = Lice(organization="Awesome Organization", project="Awesome Project")
+license_text = lice.get_license("mit")
+print(license_text)
+```
+
+This will generate the MIT license text with the organization and project name
+replaced with the values you provided, using the current year as the default.
+
+## Construct a Lice object
+
+To use `lice2` in your own project, you first need to construct a `Lice` object.
+
+```python
+from lice2.api import Lice
+
+lice = Lice(organization="Awesome Organization", project="Awesome Project")
+```
+
+This is the minimum required to construct a `Lice` object. The organization and
+project name are required to generate a license. If you don't provide them, the
+class will raise a `TypeError`.
+
+You can also pass a year to the constructor if you want to use a different year
+for any reason (can be useful for testing). This can be an integer or a string.
+
+```python
+from lice2.api import Lice
+
+lice = Lice(
+  organization="Awesome Organization",
+  project="Awesome Project",
+  year="2022"
+)
+```
+
+## Methods
+
+There are several other methods available in the API. These are called on the
+`Lice` object you created.
+
+### `get_license`
+
+This method generates a license text based on the license name you provide. The
+license name must be a valid (existing) license name. You can get a list of
+valid license names using the `get_licenses` method.
+
+```python
+license_text = lice.get_license("mit")
+print(license_text)
+```
+
+```pre
+The MIT License (MIT)
+Copyright (c) 2024 Grant Ramsay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+...
+```
+
+If you provide an invalid license name, the method will raise a
+`lice2.exceptions.LicenseNotFoundError` exception.
+
+You can pass an optional `language` argument to the method to generate the
+license text as a commented block in the specified language. This can be useful
+for generating license headers in source code files. You can get a list of valid
+languages using the `get_languages` method. Note that the value passed should be
+the **file extension** of the language (ie 'py' for Python, 'js' for JavaScript
+etc) exactly as you would from the CLI.
+
+```python
+license_text = lice.get_license("mit", language="py")
+print(license_text)
+```
+
+```pre
+# The MIT License (MIT)
+# Copyright (c) 2024 Grant Ramsay
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+...
+```
+
+If you provide an invalid language name, the method will raise a
+`lice2.exceptions.LanguageNotFoundError` exception.
+
+### `get_header`
+
+Return the header of the given license. This is a stripped-down version of the
+license text that is suitable for use as a header in source code files.
+
+If the language is specified, the header will be formatted as a commented block
+for that language. If not, the header will be returned as a plain text block.
+
+Note: Not all licenses have headers, if the license does not have a header, this
+method will raise a `lice2.exceptions.HeaderNotFoundError` exception.
+
+```python
+header_text = lice.get_header("gpl3")
+print(header_text)
+```
+
+```pre
+lice2
+Copyright (C) 2024  Grant Ramsay
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+...
+```
+
+As with the `get_license` method, you can pass an optional `language` argument
+to the method to generate the header as a commented block in the specified
+language.
+
+```python
+header_text = lice.get_header("gpl3", language="py")
+print(header_text)
+```
+
+```pre
+# lice2
+# Copyright (C) 2024  Grant Ramsay
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+...
+```
+
+### `get_licenses`
+
+This method returns a Python `list` of valid license names that can be used with
+the other methods. Uesful for generating a list of licenses to display to the
+user.
+
+!!! info
+    This method will probably be upgraded in the future to return a 'Human
+    Readable' item also.
+
+```python
+licenses = lice.get_licenses()
+print(licenses)
+```
+
+```pre
+['agpl3', 'apache', 'bsd2', 'bsd3', 'cc0', 'epl', 'gpl2', 'gpl3', ...]
+```
+
+### `get_languages`
+
+This method returns a Python `list` of valid language names that can be used with
+the other methods. Note that these are the standard **file extensions** for the
+languages.
+
+```python
+languages = lice.get_languages()
+print(languages)
+```
+
+```pre
+['c', 'cpp', 'css', 'html', 'java', 'js', 'json', 'lua', 'py', ...]
+```
+
+## Exceptions
+
+There are several exceptions that can be raised by the API methods. These are
+all subclasses of `lice2.exceptions.LiceError`, and should be caught and
+handled.
+
+They can be imported from the `lice2.exceptions` module.
+
+```python
+from lice2.exceptions import LicenseNotFoundError
+```
+
+You can get the offending attribute value by appending it to the `value`
+attribute of the exception object. For example, to get the license name that was
+invalid, you would access the `<exception>.value.license_name`:
+
+```python
+try:
+  license_text = lice.get_license("invalid")
+except LicenseNotFoundError as exc:
+  print(f"Invalid license name: {exc.value.license_name}")
+```
+
+### `LicenseNotFoundError`
+
+Raised when the license name provided to the `get_license` method is not a valid
+license name.
+
+### `LanguageNotFoundError`
+
+Raised when the language name provided to the `get_license` method is not a
+valid language name.
+
+### `HeaderNotFoundError`
+
+Raised when the specified license does not have a header available.
+
+### `InvalidYearError`
+
+Raised when the year provided to the `Lice` constructor is not a valid year, ie
+it is longer than 4 characters or cannot be converted to an integer.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -100,6 +100,22 @@ The mit license template contains the following variables:
   organization
 ```
 
+## Integrating into your own project
+
+You can integrate lice in your own project to generate licenses. Here is an
+example:
+
+```python
+from lice2.api import Lice
+
+lice = Lice(organization="Awesome Organization", project="Awesome Project")
+license_text = lice.get_license("mit")
+print(license_text)
+```
+
+There are a few more methods available in the API, see the
+[Integration](integration.md) page for more information.
+
 ## I want XXXXXXXXX license in here!
 
 Great! Is it a license that is commonly used? If so, open an issue or, if you

--- a/lice2/api/__init__.py
+++ b/lice2/api/__init__.py
@@ -1,0 +1,5 @@
+"""Module to implement the public API of the package."""
+
+from .api import Lice
+
+__all__ = ["Lice"]

--- a/lice2/api/api.py
+++ b/lice2/api/api.py
@@ -38,8 +38,8 @@ class Lice:
         """
         self.organization = organization
         self.project = project
-        if len(year) != 4:  # noqa: PLR2004
-            message = f"Year '{year}' is not a valid year (must be 4 digits)."
+        if not isinstance(year, str) or len(year) != 4:  # noqa: PLR2004
+            message = f"Year '{year}' is not a valid year."
             raise InvalidYearError(message)
         self.year = year
 

--- a/lice2/api/api.py
+++ b/lice2/api/api.py
@@ -1,0 +1,50 @@
+"""This defines an API that other Python code can use to interact with LICE2."""
+
+from lice2.constants import LANGS, LICENSES
+
+
+class Lice:
+    """List or Generate a License from many supported licenses."""
+
+    def __init__(self, organization: str, project: str) -> None:
+        """Initialize the Lice object.
+
+        Args:
+            organization: The name of the organization that owns the project.
+            project: The name of the project.
+
+        Note that not all licenses will use the 'project' field.
+
+        Example:
+        >>> lice = Lice(organization="Awesome Co.", project="my_project")
+        """
+        self.organization = organization
+        self.project = project
+
+    def get_licenses(self) -> list[str]:
+        """Return a list of all licenses in the system.
+
+        This returns a list of strings, where each string is the name of a
+        license that can then be used to generate or retrieve the text of that
+        license.
+
+        Example:
+            >>> lice = Lice(organization="Awesome Co.", project="my_project")
+            >>> lice.get_licenses()
+            ['apache', 'bsd2', 'bsd3', 'gpl2', 'gpl3', ...]
+        """
+        return LICENSES
+
+    def get_languages(self) -> list[str]:
+        """Return a list of all supported languages.
+
+        This returns a list of strings, where each string is the name of a
+        language EXTENSION that can be used to generate a license in that
+        language format.
+
+        Example:
+            >>> lice = Lice(organization="Awesome Co.", project="my_project")
+            >>> lice.get_languages()
+            ['py', 'js', 'c', 'cpp', 'java', 'rs', 'rb', 'sh', 'html', ...]
+        """
+        return list(LANGS.keys())

--- a/lice2/api/api.py
+++ b/lice2/api/api.py
@@ -41,10 +41,16 @@ class Lice:
         """
         self.organization = organization
         self.project = project
+
+        try:
+            # make sure the year can be a valid integer
+            _ = int(year)
+        except ValueError:
+            raise InvalidYearError(year) from None
+
         self.year = str(year)
         if len(self.year) != 4:  # noqa: PLR2004
-            message = f"Year '{year}' is not a valid year."
-            raise InvalidYearError(message)
+            raise InvalidYearError(year) from None
 
     def get_licenses(self) -> list[str]:
         """Return a list of all licenses in the system.
@@ -106,7 +112,7 @@ class Lice:
     def get_header(self, license_name: str, language: str = "") -> str:
         """Return the header of the given license suitable for source files.
 
-        If the #language is specified, the header will be formatted as a
+        If the language is specified, the header will be formatted as a
         commented block for that language. If not, the header will be returned
         as a plain text block.
 

--- a/lice2/api/api.py
+++ b/lice2/api/api.py
@@ -1,17 +1,30 @@
 """This defines an API that other Python code can use to interact with LICE2."""
 
+from lice2.api.exceptions import LanguageNotFoundError, LicenseNotFoundError
 from lice2.constants import LANGS, LICENSES
+from lice2.helpers import (
+    format_license,
+    generate_license,
+    get_local_year,
+    load_package_template,
+)
 
 
 class Lice:
     """List or Generate a License from many supported licenses."""
 
-    def __init__(self, organization: str, project: str) -> None:
+    def __init__(
+        self,
+        organization: str,
+        project: str,
+        year: str = get_local_year(),
+    ) -> None:
         """Initialize the Lice object.
 
         Args:
             organization: The name of the organization that owns the project.
             project: The name of the project.
+            year: The year to use in the license. Defaults to the current year.
 
         Note that not all licenses will use the 'project' field.
 
@@ -20,6 +33,7 @@ class Lice:
         """
         self.organization = organization
         self.project = project
+        self.year = year
 
     def get_licenses(self) -> list[str]:
         """Return a list of all licenses in the system.
@@ -48,3 +62,32 @@ class Lice:
             ['py', 'js', 'c', 'cpp', 'java', 'rs', 'rb', 'sh', 'html', ...]
         """
         return list(LANGS.keys())
+
+    def get_license(self, license_name: str, language: str = "") -> str:
+        """Return the text of the given license.
+
+        Args:
+            license_name: The name of the license to retrieve.
+            language: [OPTIONAL] If set, comment the license for that language.
+
+        Examples:
+            >>> lice = Lice(organization="Awesome Co.", project="my_project")
+            >>> licence_txt = Lice.get_license("mit")
+        """
+        args = {
+            "year": self.year,
+            "organization": self.organization,
+            "project": self.project,
+        }
+        try:
+            template = load_package_template(license_name)
+        except FileNotFoundError:
+            raise LicenseNotFoundError(license_name) from None
+
+        content = generate_license(template, args)
+
+        try:
+            out = format_license(content, language)
+        except KeyError:
+            raise LanguageNotFoundError(language) from None
+        return out.getvalue()

--- a/lice2/api/api.py
+++ b/lice2/api/api.py
@@ -1,5 +1,7 @@
 """This defines an API that other Python code can use to interact with LICE2."""
 
+from __future__ import annotations
+
 from lice2.api.exceptions import (
     HeaderNotFoundError,
     InvalidYearError,
@@ -22,7 +24,7 @@ class Lice:
         self,
         organization: str,
         project: str,
-        year: str = get_local_year(),
+        year: str | int = get_local_year(),
     ) -> None:
         """Initialize the Lice object.
 
@@ -30,6 +32,7 @@ class Lice:
             organization: The name of the organization that owns the project.
             project: The name of the project.
             year: The year to use in the license. Defaults to the current year.
+                (can be a string or an integer)
 
         Note that not all licenses will use the 'project' field.
 
@@ -38,10 +41,10 @@ class Lice:
         """
         self.organization = organization
         self.project = project
-        if not isinstance(year, str) or len(year) != 4:  # noqa: PLR2004
+        self.year = str(year)
+        if len(self.year) != 4:  # noqa: PLR2004
             message = f"Year '{year}' is not a valid year."
             raise InvalidYearError(message)
-        self.year = year
 
     def get_licenses(self) -> list[str]:
         """Return a list of all licenses in the system.

--- a/lice2/api/exceptions.py
+++ b/lice2/api/exceptions.py
@@ -44,3 +44,18 @@ class HeaderNotFoundError(LiceError):
         super().__init__(
             f"License '{self.license_name}' does not have any headers."
         )
+
+
+class InvalidYearError(LiceError):
+    """Raised when an invalid year is supplied."""
+
+    def __init__(self, year: str) -> None:
+        """Initialize the InvalidYearError exception.
+
+        Args:
+            year: The year that was not valid.
+        """
+        self.year = year
+        super().__init__(
+            f"Year '{self.year}' is not a valid year (must be 4 digits)."
+        )

--- a/lice2/api/exceptions.py
+++ b/lice2/api/exceptions.py
@@ -59,6 +59,5 @@ class InvalidYearError(LiceError):
         """
         self.year = year
         super().__init__(
-            f"Year '{self.year}' is not a valid year (must be a 4 digit "
-            "string)."
+            f"Year '{self.year}' is not a valid year (must be 4 digits)."
         )

--- a/lice2/api/exceptions.py
+++ b/lice2/api/exceptions.py
@@ -1,5 +1,7 @@
 """Define custom exceptions for the API."""
 
+from __future__ import annotations
+
 
 class LiceError(Exception):
     """Base class for all exceptions in the Lice API."""
@@ -49,7 +51,7 @@ class HeaderNotFoundError(LiceError):
 class InvalidYearError(LiceError):
     """Raised when an invalid year is supplied."""
 
-    def __init__(self, year: str) -> None:
+    def __init__(self, year: str | int) -> None:
         """Initialize the InvalidYearError exception.
 
         Args:
@@ -57,5 +59,6 @@ class InvalidYearError(LiceError):
         """
         self.year = year
         super().__init__(
-            f"Year '{self.year}' is not a valid year (must be 4 digits)."
+            f"Year '{self.year}' is not a valid year (must be a 4 digit "
+            "string)."
         )

--- a/lice2/api/exceptions.py
+++ b/lice2/api/exceptions.py
@@ -1,0 +1,46 @@
+"""Define custom exceptions for the API."""
+
+
+class LiceError(Exception):
+    """Base class for all exceptions in the Lice API."""
+
+
+class LicenseNotFoundError(LiceError):
+    """Raised when a license is not found in the database."""
+
+    def __init__(self, license_name: str) -> None:
+        """Initialize the LicenseNotFoundError exception.
+
+        Args:
+            license_name: The name of the license that was not found.
+        """
+        self.license_name = license_name
+        super().__init__(f"License '{self.license_name}' is unknown.")
+
+
+class LanguageNotFoundError(LiceError):
+    """Raised when a language is not found in the database."""
+
+    def __init__(self, language_name: str) -> None:
+        """Initialize the LanguageNotFoundError exception.
+
+        Args:
+            language_name: The name of the language that was not found.
+        """
+        self.language_name = language_name
+        super().__init__(f"Language '{self.language_name}' is unknown.")
+
+
+class HeaderNotFoundError(LiceError):
+    """Raised when a header is not found for the supplied license."""
+
+    def __init__(self, license_name: str) -> None:
+        """Initialize the NoHeaderFoundError exception.
+
+        Args:
+            license_name: The name of the license without a header.
+        """
+        self.license_name = license_name
+        super().__init__(
+            f"License '{self.license_name}' does not have any headers."
+        )

--- a/lice2/core.py
+++ b/lice2/core.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Annotated, Optional
@@ -22,6 +21,7 @@ from lice2.helpers import (
     generate_license,
     get_context,
     get_lang,
+    get_local_year,
     get_metadata,
     get_suffix,
     guess_organization,
@@ -88,7 +88,7 @@ def main(  # noqa: C901, PLR0912, PLR0913
         typer.Option(
             "--year", "-y", help="Copyright year", callback=validate_year
         ),
-    ] = "%i" % datetime.now().date().year,  # noqa: DTZ005
+    ] = get_local_year(),
     language: Annotated[
         Optional[str],
         typer.Option(

--- a/lice2/helpers.py
+++ b/lice2/helpers.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 import sys
 from contextlib import closing
+from datetime import datetime
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -341,3 +342,8 @@ def get_metadata(args: SimpleNamespace) -> str:
     sys.stdout.write(json.dumps(metadata) + "\n")
 
     raise typer.Exit(0)
+
+
+def get_local_year() -> str:
+    """Return the current year using the local timezone."""
+    return f"{datetime.now().astimezone().year}"

--- a/lice2/tests/test_api.py
+++ b/lice2/tests/test_api.py
@@ -63,11 +63,15 @@ class TestAPI:
         bad_year = "202"
         with pytest.raises(InvalidYearError) as exc_info:
             raise InvalidYearError(bad_year)
-        assert (
-            str(exc_info.value)
-            == "Year '202' is not a valid year (must be 4 digits)."
-        )
+        assert "Year '202' is not a valid year" in str(exc_info.value)
         assert exc_info.value.year == bad_year
+
+    def test_year_not_string_error(self) -> None:
+        """Test that InvalidYearError is raised correctly."""
+        bad_year = 2024
+        with pytest.raises(InvalidYearError) as exc_info:
+            raise InvalidYearError(bad_year)
+        assert "Year '2024' is not a valid year" in str(exc_info.value)
 
     def test_license_not_found_error(self) -> None:
         """Test that LicenseNotFoundError is raised correctly."""

--- a/lice2/tests/test_api.py
+++ b/lice2/tests/test_api.py
@@ -5,6 +5,7 @@ import pytest
 from lice2.api import Lice
 from lice2.api.exceptions import (
     HeaderNotFoundError,
+    InvalidYearError,
     LanguageNotFoundError,
     LicenseNotFoundError,
 )
@@ -30,6 +31,13 @@ class TestAPI:
         assert lice.organization == "Awesome Co."
         assert lice.project == "my_project"
 
+    def test_lice_instance_invalid_year(self) -> None:
+        """Test that creating a Lice instance with an invalid year fails."""
+        with pytest.raises(InvalidYearError) as exc_info:
+            Lice(organization="Awesome Co.", project="my_project", year="202")
+
+        assert "'202' is not a valid year" in str(exc_info.value)
+
     def test_license_not_found_error_no_arg(self) -> None:
         """Test that raising LicenseNotFoundError without an argument fails."""
         with pytest.raises(TypeError):
@@ -44,6 +52,22 @@ class TestAPI:
         """Test that raising HeaderNotFoundError without an argument fails."""
         with pytest.raises(TypeError):
             raise HeaderNotFoundError  # type: ignore[call-arg]
+
+    def test_invalid_year_error_no_arg(self) -> None:
+        """Test that raising InvalidYearError without an argument fails."""
+        with pytest.raises(TypeError):
+            raise InvalidYearError  # type: ignore[call-arg]
+
+    def test_invalid_year_error(self) -> None:
+        """Test that InvalidYearError is raised correctly."""
+        bad_year = "202"
+        with pytest.raises(InvalidYearError) as exc_info:
+            raise InvalidYearError(bad_year)
+        assert (
+            str(exc_info.value)
+            == "Year '202' is not a valid year (must be 4 digits)."
+        )
+        assert exc_info.value.year == bad_year
 
     def test_license_not_found_error(self) -> None:
         """Test that LicenseNotFoundError is raised correctly."""

--- a/lice2/tests/test_api.py
+++ b/lice2/tests/test_api.py
@@ -9,6 +9,7 @@ from lice2.api.exceptions import (
     LicenseNotFoundError,
 )
 from lice2.constants import LANGS, LICENSES
+from lice2.helpers import get_local_year
 
 
 @pytest.fixture
@@ -20,72 +21,103 @@ def lice() -> Lice:
     )
 
 
-def test_lice_instance(lice: Lice) -> None:
-    """Test that the Lice instance is created correctly."""
-    assert isinstance(lice, Lice)
-    assert lice.organization == "Awesome Co."
-    assert lice.project == "my_project"
+class TestAPI:
+    """A test class for the API."""
 
+    def test_lice_instance(self, lice: Lice) -> None:
+        """Test that the Lice instance is created correctly."""
+        assert isinstance(lice, Lice)
+        assert lice.organization == "Awesome Co."
+        assert lice.project == "my_project"
 
-def test_license_not_found_error_no_arg() -> None:
-    """Test that raising LicenseNotFoundError without an argument fails."""
-    with pytest.raises(TypeError):
-        raise LicenseNotFoundError  # type: ignore[call-arg]
+    def test_license_not_found_error_no_arg(self) -> None:
+        """Test that raising LicenseNotFoundError without an argument fails."""
+        with pytest.raises(TypeError):
+            raise LicenseNotFoundError  # type: ignore[call-arg]
 
+    def test_language_not_found_error_no_arg(self) -> None:
+        """Test that raising LanguageNotFoundError without an argument fails."""
+        with pytest.raises(TypeError):
+            raise LanguageNotFoundError  # type: ignore[call-arg]
 
-def test_language_not_found_error_no_arg() -> None:
-    """Test that raising LanguageNotFoundError without an argument fails."""
-    with pytest.raises(TypeError):
-        raise LanguageNotFoundError  # type: ignore[call-arg]
+    def test_header_not_found_error_no_arg(self) -> None:
+        """Test that raising HeaderNotFoundError without an argument fails."""
+        with pytest.raises(TypeError):
+            raise HeaderNotFoundError  # type: ignore[call-arg]
 
+    def test_license_not_found_error(self) -> None:
+        """Test that LicenseNotFoundError is raised correctly."""
+        bad_license = "unknown_license"
+        with pytest.raises(LicenseNotFoundError) as exc_info:
+            raise LicenseNotFoundError(bad_license)
+        assert str(exc_info.value) == "License 'unknown_license' is unknown."
+        assert exc_info.value.license_name == "unknown_license"
 
-def test_header_not_found_error_no_arg() -> None:
-    """Test that raising HeaderNotFoundError without an argument fails."""
-    with pytest.raises(TypeError):
-        raise HeaderNotFoundError  # type: ignore[call-arg]
+    def test_language_not_found_error(self) -> None:
+        """Test that LanguageNotFoundError is raised correctly."""
+        bad_language = "unknown_language"
+        with pytest.raises(LanguageNotFoundError) as exc_info:
+            raise LanguageNotFoundError(bad_language)
+        assert str(exc_info.value) == "Language 'unknown_language' is unknown."
+        assert exc_info.value.language_name == "unknown_language"
 
+    def test_header_not_found_error(self) -> None:
+        """Test that HeaderNotFoundError is raised correctly."""
+        license_name = "unknown_license"
+        with pytest.raises(HeaderNotFoundError) as exc_info:
+            raise HeaderNotFoundError(license_name)
+        assert (
+            str(exc_info.value)
+            == "License 'unknown_license' does not have any headers."
+        )
+        assert exc_info.value.license_name == "unknown_license"
 
-def test_license_not_found_error() -> None:
-    """Test that LicenseNotFoundError is raised correctly."""
-    bad_license = "unknown_license"
-    with pytest.raises(LicenseNotFoundError) as exc_info:
-        raise LicenseNotFoundError(bad_license)
-    assert str(exc_info.value) == "License 'unknown_license' is unknown."
-    assert exc_info.value.license_name == "unknown_license"
+    def test_get_licenses(self, lice: Lice) -> None:
+        """Test that get_licenses returns a list of licenses."""
+        licenses = lice.get_licenses()
+        assert isinstance(licenses, list)
+        assert len(licenses) == len(LICENSES)
+        assert all(isinstance(license_name, str) for license_name in licenses)
 
+    def test_get_languages(self, lice: Lice) -> None:
+        """Test that get_languages returns a list of languages."""
+        languages = lice.get_languages()
+        assert isinstance(languages, list)
+        assert len(languages) == len(LANGS.keys())
+        assert all(isinstance(language, str) for language in languages)
 
-def test_language_not_found_error() -> None:
-    """Test that LanguageNotFoundError is raised correctly."""
-    bad_language = "unknown_language"
-    with pytest.raises(LanguageNotFoundError) as exc_info:
-        raise LanguageNotFoundError(bad_language)
-    assert str(exc_info.value) == "Language 'unknown_language' is unknown."
-    assert exc_info.value.language_name == "unknown_language"
+    def test_get_license(self, lice: Lice) -> None:
+        """Test we can get a standard license.
 
+        We'll use the AFL3 license as it uses all 3 context vars.
+        """
+        license_txt = lice.get_license("afl3")
 
-def test_header_not_found_error() -> None:
-    """Test that HeaderNotFoundError is raised correctly."""
-    license_name = "unknown_license"
-    with pytest.raises(HeaderNotFoundError) as exc_info:
-        raise HeaderNotFoundError(license_name)
-    assert (
-        str(exc_info.value)
-        == "License 'unknown_license' does not have any headers."
-    )
-    assert exc_info.value.license_name == "unknown_license"
+        this_year = get_local_year()
 
+        assert "Academic Free License" in license_txt
+        assert "Awesome Co." in license_txt
+        assert "my_project" in license_txt
+        assert str(this_year) in license_txt
 
-def test_get_licenses(lice: Lice) -> None:
-    """Test that get_licenses returns a list of licenses."""
-    licenses = lice.get_licenses()
-    assert isinstance(licenses, list)
-    assert len(licenses) == len(LICENSES)
-    assert all(isinstance(license_name, str) for license_name in licenses)
+    def test_get_license_unknown(self, lice: Lice) -> None:
+        """Test that get_license raises an exception for unknown licenses."""
+        with pytest.raises(LicenseNotFoundError) as exc_info:
+            lice.get_license("unknown_license")
+        assert str(exc_info.value) == "License 'unknown_license' is unknown."
+        assert exc_info.value.license_name == "unknown_license"
 
+    def test_get_license_language(self, lice: Lice) -> None:
+        """Test we can get a license for a specific language."""
+        license_txt = lice.get_license("mit", language="py")
 
-def test_get_languages(lice: Lice) -> None:
-    """Test that get_languages returns a list of languages."""
-    languages = lice.get_languages()
-    assert isinstance(languages, list)
-    assert len(languages) == len(LANGS.keys())
-    assert all(isinstance(language, str) for language in languages)
+        assert "The MIT License (MIT)" in license_txt
+        for line in license_txt.splitlines():
+            assert line.startswith("#")
+
+    def test_get_license_language_unknown(self, lice: Lice) -> None:
+        """Test that get_license raises an exception for unknown languages."""
+        with pytest.raises(LanguageNotFoundError) as exc_info:
+            lice.get_license("mit", language="unknown_language")
+        assert str(exc_info.value) == "Language 'unknown_language' is unknown."
+        assert exc_info.value.language_name == "unknown_language"

--- a/lice2/tests/test_api.py
+++ b/lice2/tests/test_api.py
@@ -38,6 +38,11 @@ class TestAPI:
 
         assert "'202' is not a valid year" in str(exc_info.value)
 
+    def test_lice_instance_integer_year(self) -> None:
+        """Test that creating a Lice instance with an integer year works."""
+        lice = Lice(organization="Awesome Co.", project="my_project", year=1314)
+        assert lice.year == "1314"
+
     def test_license_not_found_error_no_arg(self) -> None:
         """Test that raising LicenseNotFoundError without an argument fails."""
         with pytest.raises(TypeError):
@@ -65,13 +70,6 @@ class TestAPI:
             raise InvalidYearError(bad_year)
         assert "Year '202' is not a valid year" in str(exc_info.value)
         assert exc_info.value.year == bad_year
-
-    def test_year_not_string_error(self) -> None:
-        """Test that InvalidYearError is raised correctly."""
-        bad_year = 2024
-        with pytest.raises(InvalidYearError) as exc_info:
-            raise InvalidYearError(bad_year)
-        assert "Year '2024' is not a valid year" in str(exc_info.value)
 
     def test_license_not_found_error(self) -> None:
         """Test that LicenseNotFoundError is raised correctly."""

--- a/lice2/tests/test_api.py
+++ b/lice2/tests/test_api.py
@@ -145,3 +145,33 @@ class TestAPI:
             lice.get_license("mit", language="unknown_language")
         assert str(exc_info.value) == "Language 'unknown_language' is unknown."
         assert exc_info.value.language_name == "unknown_language"
+
+    def test_get_license_header(self, lice: Lice) -> None:
+        """Test we can get a license header."""
+        header = lice.get_header("gpl3")
+
+        assert "This program is free software:" in header
+        assert "GNU General Public License" in header
+
+    def test_get_license_header_language(self, lice: Lice) -> None:
+        """Test we can get a license header for a specific language."""
+        header = lice.get_header("gpl3", language="py")
+
+        assert "This program is free software:" in header
+        assert "GNU General Public License" in header
+        for line in header.splitlines():
+            assert line.startswith("#")
+
+    def test_get_license_header_not_exists(self, lice: Lice) -> None:
+        """Test that get_license_header raises an exception for no header."""
+        with pytest.raises(HeaderNotFoundError) as exc_info:
+            lice.get_header("mit")
+        assert str(exc_info.value) == "License 'mit' does not have any headers."
+        assert exc_info.value.license_name == "mit"
+
+    def test_get_license_header_language_unknown(self, lice: Lice) -> None:
+        """Test get_license_header raises an exception for unknown languages."""
+        with pytest.raises(LanguageNotFoundError) as exc_info:
+            lice.get_header("gpl3", language="unknown_language")
+        assert str(exc_info.value) == "Language 'unknown_language' is unknown."
+        assert exc_info.value.language_name == "unknown_language"

--- a/lice2/tests/test_api.py
+++ b/lice2/tests/test_api.py
@@ -3,6 +3,11 @@
 import pytest
 
 from lice2.api import Lice
+from lice2.api.exceptions import (
+    HeaderNotFoundError,
+    LanguageNotFoundError,
+    LicenseNotFoundError,
+)
 from lice2.constants import LANGS, LICENSES
 
 
@@ -20,6 +25,54 @@ def test_lice_instance(lice: Lice) -> None:
     assert isinstance(lice, Lice)
     assert lice.organization == "Awesome Co."
     assert lice.project == "my_project"
+
+
+def test_license_not_found_error_no_arg() -> None:
+    """Test that raising LicenseNotFoundError without an argument fails."""
+    with pytest.raises(TypeError):
+        raise LicenseNotFoundError  # type: ignore[call-arg]
+
+
+def test_language_not_found_error_no_arg() -> None:
+    """Test that raising LanguageNotFoundError without an argument fails."""
+    with pytest.raises(TypeError):
+        raise LanguageNotFoundError  # type: ignore[call-arg]
+
+
+def test_header_not_found_error_no_arg() -> None:
+    """Test that raising HeaderNotFoundError without an argument fails."""
+    with pytest.raises(TypeError):
+        raise HeaderNotFoundError  # type: ignore[call-arg]
+
+
+def test_license_not_found_error() -> None:
+    """Test that LicenseNotFoundError is raised correctly."""
+    bad_license = "unknown_license"
+    with pytest.raises(LicenseNotFoundError) as exc_info:
+        raise LicenseNotFoundError(bad_license)
+    assert str(exc_info.value) == "License 'unknown_license' is unknown."
+    assert exc_info.value.license_name == "unknown_license"
+
+
+def test_language_not_found_error() -> None:
+    """Test that LanguageNotFoundError is raised correctly."""
+    bad_language = "unknown_language"
+    with pytest.raises(LanguageNotFoundError) as exc_info:
+        raise LanguageNotFoundError(bad_language)
+    assert str(exc_info.value) == "Language 'unknown_language' is unknown."
+    assert exc_info.value.language_name == "unknown_language"
+
+
+def test_header_not_found_error() -> None:
+    """Test that HeaderNotFoundError is raised correctly."""
+    license_name = "unknown_license"
+    with pytest.raises(HeaderNotFoundError) as exc_info:
+        raise HeaderNotFoundError(license_name)
+    assert (
+        str(exc_info.value)
+        == "License 'unknown_license' does not have any headers."
+    )
+    assert exc_info.value.license_name == "unknown_license"
 
 
 def test_get_licenses(lice: Lice) -> None:

--- a/lice2/tests/test_api.py
+++ b/lice2/tests/test_api.py
@@ -1,0 +1,38 @@
+"""Test suite for the programmatic API of lice2."""
+
+import pytest
+
+from lice2.api import Lice
+from lice2.constants import LANGS, LICENSES
+
+
+@pytest.fixture
+def lice() -> Lice:
+    """Return a Lice instance for testing."""
+    return Lice(
+        organization="Awesome Co.",
+        project="my_project",
+    )
+
+
+def test_lice_instance(lice: Lice) -> None:
+    """Test that the Lice instance is created correctly."""
+    assert isinstance(lice, Lice)
+    assert lice.organization == "Awesome Co."
+    assert lice.project == "my_project"
+
+
+def test_get_licenses(lice: Lice) -> None:
+    """Test that get_licenses returns a list of licenses."""
+    licenses = lice.get_licenses()
+    assert isinstance(licenses, list)
+    assert len(licenses) == len(LICENSES)
+    assert all(isinstance(license_name, str) for license_name in licenses)
+
+
+def test_get_languages(lice: Lice) -> None:
+    """Test that get_languages returns a list of languages."""
+    languages = lice.get_languages()
+    assert isinstance(languages, list)
+    assert len(languages) == len(LANGS.keys())
+    assert all(isinstance(language, str) for language in languages)

--- a/lice2/tests/test_api.py
+++ b/lice2/tests/test_api.py
@@ -31,12 +31,29 @@ class TestAPI:
         assert lice.organization == "Awesome Co."
         assert lice.project == "my_project"
 
+    def test_lice_instance_no_args(self) -> None:
+        """Test that creating a Lice instance with no args fails."""
+        with pytest.raises(
+            TypeError, match="missing 2 required positional arguments"
+        ):
+            Lice()  # type: ignore[call-arg]
+
     def test_lice_instance_invalid_year(self) -> None:
         """Test that creating a Lice instance with an invalid year fails."""
         with pytest.raises(InvalidYearError) as exc_info:
             Lice(organization="Awesome Co.", project="my_project", year="202")
 
         assert "'202' is not a valid year" in str(exc_info.value)
+
+    def test_lice_instance_very_bad_year(self) -> None:
+        """Test that creating a Lice instance with a very bad year fails.
+
+        This is basically anything that cannot be converted to an integer.
+        """
+        with pytest.raises(InvalidYearError) as exc_info:
+            Lice(organization="Awesome Co.", project="my_project", year="bad1")
+
+        assert "'bad1' is not a valid year" in str(exc_info.value)
 
     def test_lice_instance_integer_year(self) -> None:
         """Test that creating a Lice instance with an integer year works."""

--- a/lice2/tests/test_lice.py
+++ b/lice2/tests/test_lice.py
@@ -522,7 +522,7 @@ def test_bad_default_license(
 
 
 def test_get_metadata_is_valid_json(
-    args, capsys: pytest.CaptureFixture[str]
+    args: SimpleNamespace, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Test the 'get_metadata' function."""
     licenses = json.dumps(LICENSES)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
   - Overview: overview.md
   - Usage: usage.md
   - Configuration: configuration.md
+  - Integration: integration.md
   - Contributing: contributing.md
   - Changelog: changelog.md
   - Future Plans: future_plans.md


### PR DESCRIPTION
Allow `lice2` to be imported to other applications and generate licenses without shelling out to run `lice`.

```python
from lice2.api import Lice

lice = Lice(organization="Awesome Organization", project="Awesome Project")
license_text = lice.get_license("mit")
print(license_text)
```

From this, there will be several useful methods to get the licenses as strings, list the available licenses and more. At this point, we'll not be writing to a file, let the parent app do that (though that may change)