### PR TITLE
Add license full nake as metadata to the template

### DIFF
--- a/lice2/constants.py
+++ b/lice2/constants.py
@@ -102,3 +102,5 @@ for file in sorted(resource_listdir(__name__, "templates")):
     match = re.match(r"template-([a-z0-9_]+).txt", file)
     if match:
         LICENSES.append(match.groups()[0])
+
+METADATA_PATTERN = r"^---\s*name:\s*(.+?)\s*---\n(.*)$"

--- a/lice2/core.py
+++ b/lice2/core.py
@@ -30,6 +30,7 @@ from lice2.helpers import (
     list_vars,
     load_file_template,
     load_package_template,
+    strip_metadata,
     validate_license,
     validate_year,
 )
@@ -237,15 +238,17 @@ def main(  # noqa: PLR0913
             out = format_license(content, lang, legacy=args.legacy)
 
         out.seek(0)
+        out_str, _ = strip_metadata(out)
         with Path(output).open(mode="w") as f:
-            f.write(out.getvalue())
+            f.write(out_str)
     else:
         out = format_license(content, lang, legacy=args.legacy)
         out.seek(0)
+        out_str, name = strip_metadata(out)
         if not args.clipboard:
-            sys.stdout.write(out.getvalue())
+            sys.stdout.write(out_str)
         else:
-            copy_to_clipboard(out)
+            copy_to_clipboard(out_str)
 
     out.close()
 

--- a/lice2/templates/template-afl3.txt
+++ b/lice2/templates/template-afl3.txt
@@ -1,3 +1,6 @@
+---
+name: Academic Free License 3.0
+---
 {{ project }}
 Copyright (C) {{ year }}  {{ organization }}
 

--- a/lice2/templates/template-agpl3.txt
+++ b/lice2/templates/template-agpl3.txt
@@ -1,3 +1,6 @@
+---
+name: GNU Affero General Public License v3.0
+---
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/lice2/templates/template-al2.txt
+++ b/lice2/templates/template-al2.txt
@@ -1,3 +1,6 @@
+---
+name: Artistic License 2.0
+---
 Artistic License 2.0
 
 Copyright (c) {{ year }}, {{ organization }}

--- a/lice2/templates/template-apache.txt
+++ b/lice2/templates/template-apache.txt
@@ -1,3 +1,6 @@
+---
+name: Apache License 2.0
+---
 Apache License
 Version 2.0, January 2004
 http://www.apache.org/licenses/

--- a/lice2/templates/template-bsd2.txt
+++ b/lice2/templates/template-bsd2.txt
@@ -1,3 +1,6 @@
+---
+name: BSD 2-Clause "Simplified" License
+---
 Copyright (c) {{ year }}, {{ organization }}
 
 All rights reserved.

--- a/lice2/templates/template-bsd3.txt
+++ b/lice2/templates/template-bsd3.txt
@@ -1,3 +1,6 @@
+---
+name: BSD 3-Clause "New" or "Revised" License
+---
 Copyright (c) {{ year }}, {{ organization }}
 
 All rights reserved.

--- a/lice2/templates/template-edl.txt
+++ b/lice2/templates/template-edl.txt
@@ -1,3 +1,6 @@
+---
+name: Eclipse Distribution License v1.0
+---
 Eclipse Distribution License - v 1.0
 
 Copyright (c) {{ year }}, {{ organization }}

--- a/lice2/templates/template-epl.txt
+++ b/lice2/templates/template-epl.txt
@@ -1,3 +1,6 @@
+---
+name: Eclipse Public License v1.0
+---
 Eclipse Public License, Version 1.0 (EPL-1.0)
 
 THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC

--- a/lice2/templates/template-eupl.txt
+++ b/lice2/templates/template-eupl.txt
@@ -1,4 +1,6 @@
-
+---
+name: European Union Public Licence v1.2
+---
 EUROPEAN UNION PUBLIC LICENCE v. 1.2
 EUPL © {{ organization }} {{ year }}
 

--- a/lice2/templates/template-gpl2.txt
+++ b/lice2/templates/template-gpl2.txt
@@ -1,3 +1,6 @@
+---
+name: GNU General Public License v2.0
+---
 The GNU General Public License (GPL-2.0)
 Version 2, June 1991
 Copyright (C) 1989, 1991 Free Software Foundation, Inc.

--- a/lice2/templates/template-gpl3.txt
+++ b/lice2/templates/template-gpl3.txt
@@ -1,4 +1,7 @@
-                    GNU GENERAL PUBLIC LICENSE
+---
+name: GNU General Public License v3.0
+---
+                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>

--- a/lice2/templates/template-isc.txt
+++ b/lice2/templates/template-isc.txt
@@ -1,3 +1,6 @@
+---
+name: Internet Systems Consortium (ISC) License
+---
 The ISC License (ISC)
 Copyright (c) {{ year }} {{ organization }}
 

--- a/lice2/templates/template-lgpl.txt
+++ b/lice2/templates/template-lgpl.txt
@@ -1,4 +1,7 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
+---
+name: GNU Lesser General Public License v3.0
+---
+                  GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>

--- a/lice2/templates/template-mit.txt
+++ b/lice2/templates/template-mit.txt
@@ -1,3 +1,6 @@
+---
+name: MIT Licese
+---
 The MIT License (MIT)
 Copyright (c) {{ year }} {{ organization }}
 

--- a/lice2/templates/template-mpl.txt
+++ b/lice2/templates/template-mpl.txt
@@ -1,3 +1,6 @@
+---
+name: Mozilla Public License v2.0
+---
 Mozilla Public License Version 2.0
 ==================================
 

--- a/lice2/templates/template-ofl.txt
+++ b/lice2/templates/template-ofl.txt
@@ -1,4 +1,6 @@
-
+---
+name: SIL Open Font License v1.1
+---
 Copyright (c) {{ year }}, {{ organization }},
 with Reserved Font Name <Reserved Font Name>.
 

--- a/lice2/templates/template-unlicense.txt
+++ b/lice2/templates/template-unlicense.txt
@@ -1,3 +1,6 @@
+---
+name: The Unlicense
+---
 This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or

--- a/lice2/templates/template-wtfpl.txt
+++ b/lice2/templates/template-wtfpl.txt
@@ -1,7 +1,10 @@
-            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+---
+name: Do what the f**k you want to public license
+---
+           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
                     Version 2, December 2004
 
-Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+Copyright (C) {{ year }} {{ organization }}
 
 Everyone is permitted to copy and distribute verbatim or modified
 copies of this license document, and changing it is allowed as long

--- a/lice2/templates/template-zlib.txt
+++ b/lice2/templates/template-zlib.txt
@@ -1,3 +1,6 @@
+---
+name: Zlib License
+---
 Copyright (c) {{ year }} {{ organization }}
 
 This software is provided 'as-is', without any express or implied

--- a/lice2/tests/test_lice.py
+++ b/lice2/tests/test_lice.py
@@ -33,6 +33,7 @@ from lice2.helpers import (
     list_vars,
     load_file_template,
     load_package_template,
+    strip_metadata,
     validate_license,
     validate_year,
 )
@@ -547,3 +548,20 @@ class TestLice:
         assert json_result["project"] == "my_project"
         assert licenses in captured.out
         assert languages in captured.out
+
+    def test_license_strip_metadata(self) -> None:
+        """Test that metadata header is stripped from the license."""
+        license_data = io.StringIO(
+            "---\nname: Test License\n---\nLicense text."
+        )
+
+        result = strip_metadata(license_data)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2  # noqa: PLR2004
+        assert all(isinstance(item, str) for item in result)
+
+        license_body, license_name = result
+
+        assert license_name == "Test License"
+        assert license_body == "License text."


### PR DESCRIPTION
Adds a header to each of the (full) licenses with the proper license name. 

For example, for MIT:

```pre
---
name: MIT License
---
```

This is stripped out before use when the name can be recorded for later display. This is planned to be used for the license list table and future TUI mode